### PR TITLE
Use proper types as data element containers instead of `Any`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ Please follow the listed conventions when editing this file:
 
 ## Unreleased
 
+### Added
+
+- `DataElement` trait with subclasses for data type wrappers
+- helper functions for data extraction from `DataElement`
+
+### Changed
+
+- element extractors use `DataElement` now instead of `Any`
+
 ## 2.0.0 (2017-08-31)
 
 ### Fixed

--- a/benchmarks/src/main/scala/org/dfasdl/utils/benchmarks/DataElementMemoryUsage.scala
+++ b/benchmarks/src/main/scala/org/dfasdl/utils/benchmarks/DataElementMemoryUsage.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2014 - 2017  Contributors as noted in the AUTHORS.md file
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dfasdl.utils.benchmarks
+
+import java.time._
+
+import org.github.jamm.MemoryMeter
+
+object DataElementMemoryUsage {
+  final val SampleSize = 1000000
+
+  sealed trait WrapperStuff
+
+  final case class ByteWrapper(a: Array[Byte]) extends WrapperStuff
+
+  final case class LocalDateWrapper(d: LocalDate) extends WrapperStuff
+
+  final case class OffsetDateTimeWrapper(t: OffsetDateTime) extends WrapperStuff
+
+  def main(args: Array[String]): Unit = {
+    val meter = new MemoryMeter()
+    val ts    = OffsetDateTime.now()
+    println(s"A: Generating $SampleSize direct entries.")
+    val va = Vector.fill(SampleSize)(ts.plusSeconds(scala.util.Random.nextInt().toLong))
+    println("Measuring...")
+    val ba = meter.measureDeep(va)
+    val ma = "%.2f".format(ba.toDouble / 1024 / 1024)
+
+    println(s"B: Generating $SampleSize Either entries.")
+    val vb =
+      Vector.fill(SampleSize)(
+        Left(Left(Left(Right(ts.plusSeconds(scala.util.Random.nextInt().toLong)))))
+      )
+    println("Measuring...")
+    val bb = meter.measureDeep(vb)
+    val mb = "%.2f".format(bb.toDouble / 1024 / 1024)
+
+    println(s"C: Generating $SampleSize wrapper class entries.")
+    val vc = Vector.fill(SampleSize)(
+      OffsetDateTimeWrapper(ts.plusSeconds(scala.util.Random.nextInt().toLong))
+    )
+    println("Measuring...")
+    val bc = meter.measureDeep(vc)
+    val mc = "%.2f".format(bc.toDouble / 1024 / 1024)
+
+    println(s"D: Generating $SampleSize direct entries.")
+    val vd = Vector.fill(SampleSize)(
+      ts.plusSeconds(scala.util.Random.nextInt().toLong).toLocalDate
+    )
+    println("Measuring...")
+    val bd = meter.measureDeep(vd)
+    val md = "%.2f".format(bd.toDouble / 1024 / 1024)
+
+    println(s"E: Generating $SampleSize Either entries.")
+    val ve = Vector.fill(SampleSize)(
+      Left(Left(Left(Left(Right(ts.plusSeconds(scala.util.Random.nextInt().toLong).toLocalDate)))))
+    )
+    println("Measuring...")
+    val be = meter.measureDeep(ve)
+    val me = "%.2f".format(be.toDouble / 1024 / 1024)
+
+    println(s"F: Generating $SampleSize wrapper class entries.")
+    val vf = Vector.fill(SampleSize)(
+      LocalDateWrapper(ts.plusSeconds(scala.util.Random.nextInt().toLong).toLocalDate)
+    )
+    println("Measuring...")
+    val bf = meter.measureDeep(vf)
+    val mf = "%.2f".format(bf.toDouble / 1024 / 1024)
+
+    println(s"G: Generating $SampleSize direct entries.")
+    val vg = Vector.fill(SampleSize)(
+      scala.util.Random.alphanumeric.take(40).mkString.getBytes("UTF-8")
+    )
+    println("Measuring...")
+    val bg = meter.measureDeep(vg)
+    val mg = "%.2f".format(bg.toDouble / 1024 / 1024)
+
+    println(s"H: Generating $SampleSize Either entries.")
+    val vh = Vector.fill(SampleSize)(
+      Left(scala.util.Random.alphanumeric.take(40).mkString.getBytes("UTF-8"))
+    )
+    println("Measuring...")
+    val bh = meter.measureDeep(vh)
+    val mh = "%.2f".format(bh.toDouble / 1024 / 1024)
+
+    println(s"I: Generating $SampleSize wrapper class entries.")
+    val vi = Vector.fill(SampleSize)(
+      ByteWrapper(scala.util.Random.alphanumeric.take(40).mkString.getBytes("UTF-8"))
+    )
+    println("Measuring...")
+    val bi = meter.measureDeep(vi)
+    val mi = "%.2f".format(bi.toDouble / 1024 / 1024)
+
+    println(s"Object size A:\t$ba bytes ($ma MB)")
+    println(s"Object size B:\t$bb bytes ($mb MB)")
+    println(s"Object size C:\t$bc bytes ($mc MB)")
+    println(s"Object size D:\t$bd bytes ($md MB)")
+    println(s"Object size E:\t$be bytes ($me MB)")
+    println(s"Object size F:\t$bf bytes ($mf MB)")
+    println(s"Object size G:\t$bg bytes ($mg MB)")
+    println(s"Object size H:\t$bh bytes ($mh MB)")
+    println(s"Object size I:\t$bi bytes ($mi MB)")
+  }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.1
+sbt.version = 1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,10 +4,10 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.2.27")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-ghpages"     % "0.6.2")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"         % "0.9.3")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"         % "1.1.0")
-addSbtPlugin("com.lucidchart"     % "sbt-scalafmt"    % "1.11")
+addSbtPlugin("com.lucidchart"     % "sbt-scalafmt"    % "1.12")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"   % "1.5.1")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-site"        % "1.3.0")
-addSbtPlugin("org.wartremover"    % "sbt-wartremover" % "2.2.0")
+addSbtPlugin("org.wartremover"    % "sbt-wartremover" % "2.2.1")
 
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25" // Needed by sbt-git
 

--- a/src/main/scala/org/dfasdl/utils/types/DataElement.scala
+++ b/src/main/scala/org/dfasdl/utils/types/DataElement.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014 - 2017  Contributors as noted in the AUTHORS.md file
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dfasdl.utils.types
+
+import java.math.BigDecimal
+import java.time.{ LocalDate, LocalTime, OffsetDateTime }
+
+/**
+  * A sealed trait to wrap the data element types.
+  * The general idea is to gain type safety and move away from using the
+  * dreaded `Any` as base type.
+  */
+sealed trait DataElement extends Product with Serializable
+
+/**
+  * A data element wrapper for binary data.
+  *
+  * @param v An array of bytes.
+  */
+final case class BinaryE(v: Array[Byte]) extends DataElement
+
+/**
+  * A data element wrapper for a decimal number.
+  *
+  * @param v A decimal number.
+  */
+final case class DecimalE(v: BigDecimal) extends DataElement
+
+/**
+  * A data element wrapper for an integer number.
+  *
+  * @param v An integer number.
+  */
+final case class IntegerE(v: Long) extends DataElement
+
+/**
+  * A data element wrapper for a local date.
+  *
+  * @param v A local date.
+  */
+final case class LocalDateE(v: LocalDate) extends DataElement
+
+/**
+  * A data element wrapper for a local time.
+  *
+  * @param v A local time.
+  */
+final case class LocalTimeE(v: LocalTime) extends DataElement
+
+/**
+  * A data element wrapper for an offset datetime.
+  *
+  * @param v An offset datetime.
+  */
+final case class OffsetDateTimeE(v: OffsetDateTime) extends DataElement
+
+/**
+  * A data element wrapper for a string.
+  *
+  * @param v A string.
+  */
+final case class StringE(v: String) extends DataElement

--- a/src/main/scala/org/dfasdl/utils/types/extractors.scala
+++ b/src/main/scala/org/dfasdl/utils/types/extractors.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2014 - 2017  Contributors as noted in the AUTHORS.md file
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dfasdl.utils.types
+
+import java.math.BigDecimal
+import java.time.{ LocalDate, LocalTime, OffsetDateTime }
+
+/**
+  * This object contains helper functions to extract the concrete data element
+  * type from the wrapper type.
+  */
+object extractors {
+
+  /**
+    * Extract the byte array from the given `DataElement`.
+    *
+    * @param d A data element.
+    * @return An option to the contained byte array which may be empty.
+    */
+  final def getBinary(d: DataElement): Option[Array[Byte]] = d match {
+    case BinaryE(v) => Option(v)
+    case _          => None
+  }
+
+  /**
+    * Extract the decimal number from the given `DataElement`.
+    *
+    * @param d A data element.
+    * @return An option to the contained decimal number which may be empty.
+    */
+  final def getDecimal(d: DataElement): Option[BigDecimal] = d match {
+    case DecimalE(v) => Option(v)
+    case _           => None
+  }
+
+  /**
+    * Extract the long number from the given `DataElement`.
+    *
+    * @param d A data element.
+    * @return An option to the contained long number which may be empty.
+    */
+  final def getInteger(d: DataElement): Option[Long] = d match {
+    case IntegerE(v) => Option(v)
+    case _           => None
+  }
+
+  /**
+    * Extract the local date from the given `DataElement`.
+    *
+    * @param d A data element.
+    * @return An option to the contained local date which may be empty.
+    */
+  final def getLocalDate(d: DataElement): Option[LocalDate] = d match {
+    case LocalDateE(v) => Option(v)
+    case _             => None
+  }
+
+  /**
+    * Extract the local time from the given `DataElement`.
+    *
+    * @param d A data element.
+    * @return An option to the contained local time which may be empty.
+    */
+  final def getLocalTime(d: DataElement): Option[LocalTime] = d match {
+    case LocalTimeE(v) => Option(v)
+    case _             => None
+  }
+
+  /**
+    * Extract the offset datetime from the given `DataElement`.
+    *
+    * @param d A data element.
+    * @return An option to the contained offset  which may be empty.
+    */
+  final def getOffsetDateTime(d: DataElement): Option[OffsetDateTime] = d match {
+    case OffsetDateTimeE(v) => Option(v)
+    case _                  => None
+  }
+
+  /**
+    * Extract the string from the given `DataElement`.
+    *
+    * @param d A data element.
+    * @return An option to the contained string which may be empty.
+    */
+  final def getString(d: DataElement): Option[String] = d match {
+    case StringE(v) => Option(v)
+    case _          => None
+  }
+
+}


### PR DESCRIPTION
Several approaches where evaluated and benchmarked. The implemented
approach adds a sealed trait for data elements and sub case classes that
wrap the actual data types. This adds a bit overhead but seems to be
acceptable in most cases.

### Changes

* add `DataElement` trait
* add helper functions for extraction in object `extractors`
* update sbt to 1.0.2
* update plugins